### PR TITLE
overriden equals in `Time` class

### DIFF
--- a/CalendarLibrary/Date.cs
+++ b/CalendarLibrary/Date.cs
@@ -115,8 +115,6 @@ public class Date
 
     internal bool leapYear { get => _leapYear; }
 
-    public override int GetHashCode()
-    {
-        throw new NotImplementedException();
-    }
+    // override object.GetHashCode
+    public override int GetHashCode() => base.GetHashCode();
 }

--- a/ClockLibrary/Time.cs
+++ b/ClockLibrary/Time.cs
@@ -64,4 +64,21 @@ public class Time
             _minute = value;
         }
     }
+
+    // override object.Equals
+    public override bool Equals(object? obj)
+    {
+        if (obj == null || GetType() != obj.GetType())
+        {
+            return false;
+        }
+
+        if (Hour == ((Time)obj).Hour && Minute == ((Time)obj).Minute)
+            return true;
+
+        return false;
+    }
+
+    // override object.GetHashCode
+    public override int GetHashCode() => base.GetHashCode();
 }


### PR DESCRIPTION
Implemented override of the method `Equals`
Fixes #23 